### PR TITLE
Adding file delete permission for ActiveRecord

### DIFF
--- a/protected/humhub/modules/file/models/File.php
+++ b/protected/humhub/modules/file/models/File.php
@@ -160,7 +160,7 @@ class File extends FileCompat
         }
 
         if($object !== null && $object instanceof ActiveRecord){
-            return $object->canDelete();
+            return $object->canDeleteFile();
         }
 
         // File is not bound to an object

--- a/protected/humhub/modules/file/models/File.php
+++ b/protected/humhub/modules/file/models/File.php
@@ -159,6 +159,10 @@ class File extends FileCompat
             return $object->content->canEdit($userId);
         }
 
+        if($object !== null && $object instanceof ActiveRecord){
+            return $object->canDelete();
+        }
+
         // File is not bound to an object
         if ($object == null) {
             return true;


### PR DESCRIPTION
Since i've been taking advantage from the upload component already developed by humhub and which works only with ContentActiveRecord ( Records that will be shown in humhub spaces streams ) in order to upload files for crowdfunding campaigns, and since crowdfunding records are not of the type content i was obliged to make the uploader handle them too