### PR TITLE
Revert "disable csrf check momentary for the landing page integration"

### DIFF
--- a/protected/humhub/modules/user/controllers/AuthController.php
+++ b/protected/humhub/modules/user/controllers/AuthController.php
@@ -59,10 +59,6 @@ class AuthController extends Controller
         // Remove authClient from session - if already exists
         Yii::$app->session->remove('authClient');
 
-        if ($action->id == 'login') {
-            $this->enableCsrfValidation = false;
-        }
-
         return parent::beforeAction($action);
     }
 


### PR DESCRIPTION
I've previuosly disabled csrf form check for login/register in humhub in order to allow landing page to pass emails directly to humhub's POST request..

As it turns out that this a security breach which allows crawlers to send emails randomly which triggers gmail spam police, so I have to reverts Coinsence/humhub#4 till I find a better way to integrate the landing page.