### PR TITLE
Tup#226 hide space header widget in custom pages

### DIFF
--- a/themes/Coinsence/views/space/space/_layout.php
+++ b/themes/Coinsence/views/space/space/_layout.php
@@ -17,11 +17,13 @@ $space = $context->contentContainer;
 
 ?>
 <div class="container space-layout-container">
-    <div class="row">
-        <div class="col-md-12">
-            <?= Header::widget(['space' => $space]); ?>
+    <?php if ($context->module->id !== 'custom_pages'): ?>
+        <div class="row">
+            <div class="col-md-12">
+                <?= Header::widget(['space' => $space]); ?>
+            </div>
         </div>
-    </div>
+    <?php endif; ?>
     <div class="row space-content">
         <div class="col-md-2 layout-nav-container hidden">
             <?= Menu::widget(['space' => $space]); ?>


### PR DESCRIPTION
Remove space header when viewing custom pages, may need some additional changes in order to make it fullwidth